### PR TITLE
Fix default linux plan missing setting

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,8 @@ resource "azurerm_app_service_plan" "webserviceplan" {
   resource_group_name = "${azurerm_resource_group.webapp.name}"
   
   kind                = "${var.plan_settings["kind"]}"
+
+  reserved            = "${var.plan_settings["reserved"]}"
   
   sku {
     tier     = "${var.plan_settings["tier"]}"

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,7 @@ variable "plan_settings" {
     size     = "S1"
     capacity = 1
     tier     = "Standard"
+    reserved     = true
   }
 }
 


### PR DESCRIPTION
I received the "azurerm_app_service_plan.webserviceplan: Reserved has to be set to true when using kind Linux" error when using this module. See the "note" about `Linux` app service plans here https://www.terraform.io/docs/providers/azurerm/r/app_service_plan.html\#argument-reference.

I tested locally by setting my module source to my [fork](https://www.terraform.io/docs/modules/sources.html#github) and [branch](https://www.terraform.io/docs/modules/sources.html#selecting-a-revision):
```
module "webapp" {
  #source  = "rahulkhengare/webapp/azurerm"
  source = "git@github.com:gabrieljoelc/terraform-azurerm-webapp.git?ref=linux-reserved-true-fix"
  version = "0.1.0"
  name                = "myamazingwebapp"
  resource_group_name = "proto-linux"
  location = "centralus"
}
```

TIL, about this Azure Resource Group [limitation](https://docs.microsoft.com/en-us/azure/app-service/containers/app-service-linux-intro#limitations):

> Based on a current limitation, for the same resource group you cannot mix Windows and Linux apps in the same region.